### PR TITLE
UI compatibility

### DIFF
--- a/tcp-client/Cargo.toml
+++ b/tcp-client/Cargo.toml
@@ -4,10 +4,11 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-argon2 = "0.5.3"
 dotenv = "0.15.0"
-mockito = "1.6.1"
-reqwest = { version = "0.12.12", features = ["json"] }
+reqwest-wasm = { version = "0.11.16", features = ["json"] }
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.137"
-tokio = { version = "1.43.0", features = ["full"] }
+
+[lib]
+name = "client"
+path = "src/main.rs"

--- a/tcp-client/src/api/auth.rs
+++ b/tcp-client/src/api/auth.rs
@@ -1,10 +1,8 @@
 //! Requests for the authentication endpoint
 
-#![allow(dead_code)]
-
-use crate::path::Path;
+use crate::path::auth;
 use crate::requests::send_request::send_request;
-use reqwest::{header::SET_COOKIE, Client, Method, StatusCode};
+use reqwest_wasm::{header::SET_COOKIE, Client, Method, StatusCode};
 use serde::Serialize;
 use serde_json::Value;
 
@@ -29,11 +27,10 @@ fn get_session_id(cookie_str: &str) -> Option<String> {
 /// Send request to attempt login with provided user credentials
 pub async fn user_login(
     client: &Client,
-    path: &Path,
     username: &str,
     pw: &str,
 ) -> (StatusCode, Option<Value>, Option<String>) {
-    let url = &path.get_login_url();
+    let url = auth::get_login_url();
     let params = User {
         username: username.to_string(),
         password_hash: pw.to_string(),
@@ -56,10 +53,9 @@ pub async fn user_login(
 /// Send request to log out the current user
 pub async fn user_logout(
     client: &Client,
-    path: &Path,
     session_id: &str,
 ) -> (StatusCode, Option<Value>, String) {
-    let url = &path.get_logout_url();
+    let url = auth::get_logout_url();
 
     let (status, json, headers) =
         send_request(client, &Method::POST, url, Some(session_id), None::<()>).await;
@@ -78,10 +74,9 @@ pub async fn user_logout(
 /// Send request to renew session tokens
 pub async fn renew_session(
     client: &Client,
-    path: &Path,
     session_id: &str,
 ) -> (StatusCode, Option<Value>, String) {
-    let url = &path.get_renew_url();
+    let url = auth::get_renew_url();
 
     let (status, json, headers) =
         send_request(client, &Method::POST, url, Some(session_id), None::<()>).await;

--- a/tcp-client/src/api/sensor.rs
+++ b/tcp-client/src/api/sensor.rs
@@ -1,10 +1,8 @@
 //! Requests for the sensor endpoint
 
-#![allow(dead_code)]
-
-use crate::path::Path;
+use crate::path::sensor;
 use crate::requests::send_request::send_request;
-use reqwest::{Client, Method, StatusCode};
+use reqwest_wasm::{Client, Method, StatusCode};
 use serde::Serialize;
 use serde_json::Value;
 
@@ -18,11 +16,10 @@ pub struct Sensor {
 /// Send request to create a new sensor
 pub async fn create_sensor(
     client: &Client,
-    path: &Path,
     session_id: &str,
     sensor_type: &str,
 ) -> (StatusCode, Option<Value>) {
-    let url = &path.get_sensor_url();
+    let url = sensor::get_sensor_url();
     let params = Sensor {
         sensor_type: sensor_type.to_string(),
     };
@@ -36,10 +33,9 @@ pub async fn create_sensor(
 /// Send request to get all sensors
 pub async fn view_all_sensors(
     client: &Client,
-    path: &Path,
     session_id: &str,
 ) -> (StatusCode, Option<Value>) {
-    let url = &path.get_sensor_url();
+    let url = sensor::get_sensor_url();
 
     let (status, json, _headers) =
         send_request(client, &Method::GET, url, Some(session_id), None::<()>).await;
@@ -50,11 +46,10 @@ pub async fn view_all_sensors(
 /// Send request to get a specific sensor according to given ID
 pub async fn view_sensor_by_id(
     client: &Client,
-    path: &Path,
     session_id: &str,
     sensor_id: &str,
 ) -> (StatusCode, Option<Value>) {
-    let url = &path.get_sensor_id_url(sensor_id);
+    let url = sensor::get_sensor_id_url(sensor_id);
 
     let (status, json, _headers) =
         send_request(client, &Method::GET, url, Some(session_id), None::<()>).await;
@@ -65,12 +60,11 @@ pub async fn view_sensor_by_id(
 /// Send request to partially or fully update a sensor
 pub async fn update_sensor(
     client: &Client,
-    path: &Path,
     session_id: &str,
     sensor_id: &str,
     sensor_type: &str,
 ) -> (StatusCode, Option<Value>) {
-    let url = &path.get_sensor_id_url(sensor_id);
+    let url = sensor::get_sensor_id_url(sensor_id);
     let params = Sensor {
         sensor_type: sensor_type.to_string(),
     };
@@ -84,11 +78,10 @@ pub async fn update_sensor(
 /// Send request to delete a sensor according to given ID
 pub async fn delete_sensor(
     client: &Client,
-    path: &Path,
     session_id: &str,
     sensor_id: &str,
 ) -> (StatusCode, Option<Value>) {
-    let url = &path.get_sensor_id_url(sensor_id);
+    let url = sensor::get_sensor_id_url(sensor_id);
 
     let (status, json, _headers) =
         send_request(client, &Method::DELETE, url, Some(session_id), None::<()>).await;

--- a/tcp-client/src/api/session.rs
+++ b/tcp-client/src/api/session.rs
@@ -1,10 +1,8 @@
 //! Requests for the session endpoint
 
-#![allow(dead_code)]
-
-use crate::path::Path;
+use crate::path::session;
 use crate::requests::send_request::send_request;
-use reqwest::{Client, Method, StatusCode};
+use reqwest_wasm::{Client, Method, StatusCode};
 use serde::Serialize;
 use serde_json::Value;
 
@@ -17,11 +15,10 @@ pub struct Session {
 /// Send request to create a new session
 pub async fn create_session(
     client: &Client,
-    path: &Path,
     session_id: &str,
     username: &str,
 ) -> (StatusCode, Option<Value>) {
-    let url = &path.get_sessions_url();
+    let url = session::get_sessions_url();
     let params = Session {
         username: username.to_string(),
     };
@@ -35,10 +32,9 @@ pub async fn create_session(
 /// Send request to get all session
 pub async fn view_all_sessions(
     client: &Client,
-    path: &Path,
     session_id: &str,
 ) -> (StatusCode, Option<Value>) {
-    let url = &path.get_sessions_url();
+    let url = session::get_sessions_url();
 
     let (status, json, _headers) =
         send_request(client, &Method::GET, url, Some(session_id), None::<()>).await;
@@ -49,11 +45,10 @@ pub async fn view_all_sessions(
 /// Send request to get all sessions by user
 pub async fn view_sessions_by_user(
     client: &Client,
-    path: &Path,
     session_id: &str,
     username: &str,
 ) -> (StatusCode, Option<Value>) {
-    let url = &path.get_sessions_subpath_url("user", username);
+    let url = session::get_sessions_subpath_url("user", username);
 
     let (status, json, _headers) =
         send_request(client, &Method::GET, url, Some(session_id), None::<()>).await;
@@ -64,10 +59,9 @@ pub async fn view_sessions_by_user(
 /// Send request to get a specific session by ID
 pub async fn view_session_by_id(
     client: &Client,
-    path: &Path,
     session_id: &str,
 ) -> (StatusCode, Option<Value>) {
-    let url = &path.get_sessions_subpath_url("id", session_id);
+    let url = session::get_sessions_subpath_url("id", session_id);
 
     let (status, json, _headers) =
         send_request(client, &Method::GET, url, Some(session_id), None::<()>).await;
@@ -78,11 +72,10 @@ pub async fn view_session_by_id(
 /// Send request to partially or fully update a session
 pub async fn update_session(
     client: &Client,
-    path: &Path,
     session_id: &str,
     username: &str,
 ) -> (StatusCode, Option<Value>) {
-    let url = &path.get_sessions_exp_url(session_id);
+    let url = session::get_sessions_exp_url(session_id);
     let params = Session {
         username: username.to_string(),
     };
@@ -96,10 +89,9 @@ pub async fn update_session(
 /// Send request to delete a session by ID
 pub async fn delete_session(
     client: &Client,
-    path: &Path,
     session_id: &str,
 ) -> (StatusCode, Option<Value>) {
-    let url = &path.get_sessions_exp_url(session_id);
+    let url = session::get_sessions_exp_url(session_id);
 
     let (status, json, _headers) =
         send_request(client, &Method::DELETE, url, Some(session_id), None::<()>).await;

--- a/tcp-client/src/api/session_sensor.rs
+++ b/tcp-client/src/api/session_sensor.rs
@@ -1,10 +1,8 @@
 //! Requests for the session sensor endpoint
 
-#![allow(dead_code)]
-
-use crate::path::Path;
+use crate::path::session;
 use crate::requests::send_request::send_request;
-use reqwest::{Client, Method, StatusCode};
+use reqwest_wasm::{Client, Method, StatusCode};
 use serde::Serialize;
 use serde_json::Value;
 
@@ -18,11 +16,10 @@ pub struct SessionSensor {
 /// Send request to link a new sensor to a session
 pub async fn create_session_sensor(
     client: &Client,
-    path: &Path,
     session_id: &str,
     sensor_id: &str,
 ) -> (StatusCode, Option<Value>) {
-    let url = &path.get_session_sensors_url();
+    let url = session::get_session_sensors_url();
     let params = SessionSensor {
         session_id: session_id.to_string(),
         sensor_id: sensor_id.to_string(),
@@ -37,10 +34,9 @@ pub async fn create_session_sensor(
 /// Send request to get all session sensor linkages
 pub async fn view_all_sensor_sessions(
     client: &Client,
-    path: &Path,
     session_id: &str,
 ) -> (StatusCode, Option<Value>) {
-    let url = &path.get_session_sensors_url();
+    let url = session::get_session_sensors_url();
 
     let (status, json, _headers) =
         send_request(client, &Method::GET, url, Some(session_id), None::<()>).await;
@@ -51,10 +47,9 @@ pub async fn view_all_sensor_sessions(
 /// Send request to get all sensors linked to a specific session
 pub async fn view_sensors_by_session_id(
     client: &Client,
-    path: &Path,
     session_id: &str,
 ) -> (StatusCode, Option<Value>) {
-    let url = &path.get_session_sensors_subpath_url("session", session_id);
+    let url = session::get_session_sensors_subpath_url("session", session_id);
 
     let (status, json, _headers) =
         send_request(client, &Method::GET, url, Some(session_id), None::<()>).await;
@@ -65,11 +60,10 @@ pub async fn view_sensors_by_session_id(
 /// Send request to get a specific session sensor linkage by sensor ID
 pub async fn view_session_sensor_by_sensor_id(
     client: &Client,
-    path: &Path,
     session_id: &str,
     sensor_id: &str,
 ) -> (StatusCode, Option<Value>) {
-    let url = &path.get_session_sensors_subpath_url("session-sensor", sensor_id);
+    let url = session::get_session_sensors_subpath_url("session-sensor", sensor_id);
 
     let (status, json, _headers) =
         send_request(client, &Method::GET, url, Some(session_id), None::<()>).await;
@@ -80,11 +74,10 @@ pub async fn view_session_sensor_by_sensor_id(
 /// Send request to partially or fully udpate a session sensor link
 pub async fn update_sensor_session(
     client: &Client,
-    path: &Path,
     session_id: &str,
     sensor_id: &str,
 ) -> (StatusCode, Option<Value>) {
-    let url = &path.get_session_sensors_id_url(sensor_id);
+    let url = session::get_session_sensors_id_url(sensor_id);
     let params = SessionSensor {
         session_id: session_id.to_string(),
         sensor_id: sensor_id.to_string(),
@@ -99,11 +92,10 @@ pub async fn update_sensor_session(
 /// Send request to delete a session sensor linkage by ID
 pub async fn delete_sensor_session(
     client: &Client,
-    path: &Path,
     session_id: &str,
     sensor_id: &str,
 ) -> (StatusCode, Option<Value>) {
-    let url = &path.get_session_sensors_id_url(sensor_id);
+    let url = session::get_session_sensors_id_url(sensor_id);
 
     let (status, json, _headers) =
         send_request(client, &Method::DELETE, url, Some(session_id), None::<()>).await;

--- a/tcp-client/src/api/session_sensor_data.rs
+++ b/tcp-client/src/api/session_sensor_data.rs
@@ -1,10 +1,8 @@
 //! Requests for the session sensor data endpoint
 
-#![allow(dead_code)]
-
-use crate::path::Path;
+use crate::path::datapoint;
 use crate::requests::send_request::send_request;
-use reqwest::{Client, Method, StatusCode};
+use reqwest_wasm::{Client, Method, StatusCode};
 use serde::Serialize;
 use serde_json::Value;
 
@@ -25,13 +23,12 @@ pub struct SessionSensorData {
 /// Send request to create a new datapoint
 pub async fn create_datapoint(
     client: &Client,
-    path: &Path,
     session_id: &str,
     id: &str,
     datetime: &str,
     data_blob: &str,
 ) -> (StatusCode, Option<Value>) {
-    let url = &path.get_datapoint_url();
+    let url = datapoint::get_datapoint_url();
     let params = SessionSensorData {
         id: id.to_string(),
         datetime: datetime.to_string(),
@@ -47,11 +44,10 @@ pub async fn create_datapoint(
 /// Send request to batch create new datapoints
 pub async fn batch_create_datapoint(
     client: &Client,
-    path: &Path,
     session_id: &str,
     datapoints: Vec<SessionSensorData>,
 ) -> (StatusCode, Option<Value>) {
-    let url = &path.get_batch_url();
+    let url = datapoint::get_batch_url();
     let params = Batch { datapoints };
 
     let (status, json, _headers) =
@@ -63,10 +59,9 @@ pub async fn batch_create_datapoint(
 /// Send request to get all datapoints
 pub async fn view_all_datapoints(
     client: &Client,
-    path: &Path,
     session_id: &str,
 ) -> (StatusCode, Option<Value>) {
-    let url = &path.get_datapoint_url();
+    let url = datapoint::get_datapoint_url();
 
     let (status, json, _headers) =
         send_request(client, &Method::GET, url, Some(session_id), None::<()>).await;
@@ -77,10 +72,9 @@ pub async fn view_all_datapoints(
 /// Send request to get all datapoints linked to a given session
 pub async fn view_datapoints_by_session_id(
     client: &Client,
-    path: &Path,
     session_id: &str,
 ) -> (StatusCode, Option<Value>) {
-    let url = &path.get_datapoint_subpath_url("session", session_id);
+    let url = datapoint::get_datapoint_subpath_url("session", session_id);
 
     let (status, json, _headers) =
         send_request(client, &Method::GET, url, Some(session_id), None::<()>).await;
@@ -91,11 +85,10 @@ pub async fn view_datapoints_by_session_id(
 /// Send request to get all datapoints by session sensor ID
 pub async fn view_datapoints_by_session_sensor(
     client: &Client,
-    path: &Path,
     session_id: &str,
     id: &str,
 ) -> (StatusCode, Option<Value>) {
-    let url = &path.get_datapoint_subpath_url("id", id);
+    let url = datapoint::get_datapoint_subpath_url("id", id);
 
     let (status, json, _headers) =
         send_request(client, &Method::GET, url, Some(session_id), None::<()>).await;
@@ -106,12 +99,11 @@ pub async fn view_datapoints_by_session_sensor(
 /// Send request to get a specific datapoint
 pub async fn view_datapoints_by_id_datetime(
     client: &Client,
-    path: &Path,
     session_id: &str,
     id: &str,
     datetime: &str,
 ) -> (StatusCode, Option<Value>) {
-    let url = &path.get_datapoint_subpath_url(id, datetime);
+    let url = datapoint::get_datapoint_subpath_url(id, datetime);
 
     let (status, json, _headers) =
         send_request(client, &Method::GET, url, Some(session_id), None::<()>).await;
@@ -122,13 +114,12 @@ pub async fn view_datapoints_by_id_datetime(
 /// Send request to partially or fully udpate a specific datapoint
 pub async fn update_datapoint(
     client: &Client,
-    path: &Path,
     session_id: &str,
     id: &str,
     datetime: &str,
     data_blob: &str,
 ) -> (StatusCode, Option<Value>) {
-    let url = &path.get_datapoint_subpath_url(id, datetime);
+    let url = datapoint::get_datapoint_subpath_url(id, datetime);
     let params = SessionSensorData {
         id: id.to_string(),
         datetime: datetime.to_string(),
@@ -144,12 +135,11 @@ pub async fn update_datapoint(
 /// Send request to delete a specific datapoint
 pub async fn delete_datapoint(
     client: &Client,
-    path: &Path,
     session_id: &str,
     id: &str,
     datetime: &str,
 ) -> (StatusCode, Option<Value>) {
-    let url = &path.get_datapoint_subpath_url(id, datetime);
+    let url = datapoint::get_datapoint_subpath_url(id, datetime);
 
     let (status, json, _headers) =
         send_request(client, &Method::DELETE, url, Some(session_id), None::<()>).await;

--- a/tcp-client/src/api/user.rs
+++ b/tcp-client/src/api/user.rs
@@ -1,10 +1,8 @@
 //! Requests for the user endpoint
 
-#![allow(dead_code)]
-
-use crate::path::Path;
+use crate::path::user;
 use crate::requests::send_request::send_request;
-use reqwest::{Client, Method, StatusCode};
+use reqwest_wasm::{Client, Method, StatusCode};
 use serde_json::Value;
 use serde::Serialize;
 
@@ -18,7 +16,6 @@ pub struct User {
 /// Send request to create a new user
 pub async fn create_user(
     client: &Client,
-    path: &Path,
     username: &str,
     pw: &str,
 ) -> (StatusCode, Option<Value>) {
@@ -27,7 +24,7 @@ pub async fn create_user(
         password_hash: pw.to_string(),
     };
 
-    let url = &path.get_user_url();
+    let url = user::get_user_url();
 
     let (status, json, _headers) =
         send_request(client, &Method::POST, url, None, Some(&params)).await;
@@ -38,10 +35,9 @@ pub async fn create_user(
 /// Send request to get all users
 pub async fn view_all_users(
     client: &Client,
-    path: &Path,
     session_id: &str,
 ) -> (StatusCode, Option<Value>) {
-    let url = &path.get_user_url();
+    let url = user::get_user_url();
 
     let (status, json, _headers) =
         send_request(client, &Method::GET, url, Some(session_id), None::<()>).await;
@@ -52,10 +48,9 @@ pub async fn view_all_users(
 /// Send request to get user currently loggged in
 pub async fn view_user_profile(
     client: &Client,
-    path: &Path,
     session_id: &str,
 ) -> (StatusCode, Option<Value>) {
-    let url = &path.get_profile_url();
+    let url = user::get_profile_url();
 
     let (status, json, _headers) =
         send_request(client, &Method::GET, url, Some(session_id), None::<()>).await;
@@ -66,10 +61,9 @@ pub async fn view_user_profile(
 /// Send request to get a specific user by username
 pub async fn view_user_by_username(
     client: &Client,
-    path: &Path,
     username: &str,
 ) -> (StatusCode, Option<Value>) {
-    let url = &path.get_username_url(username);
+    let url = user::get_username_url(username);
 
     let (status, json, _headers) =
         send_request(client, &Method::GET, url, None, None::<()>).await;
@@ -80,7 +74,6 @@ pub async fn view_user_by_username(
 /// Send request to partially or fully update a user
 pub async fn update_user(
     client: &Client,
-    path: &Path,
     username: &str,
     pw: &str,
 ) -> (StatusCode, Option<Value>) {
@@ -89,7 +82,7 @@ pub async fn update_user(
         password_hash: pw.to_string(),
     };
 
-    let url = &path.get_username_url(username);
+    let url = user::get_username_url(username);
 
     let (status, json, _headers) =
         send_request(client, &Method::PATCH, url, None, Some(&params)).await;
@@ -100,10 +93,9 @@ pub async fn update_user(
 /// Send request to delete a user by username
 pub async fn delete_user(
     client: &Client,
-    path: &Path,
     username: &str,
 ) -> (StatusCode, Option<Value>) {
-    let url = &path.get_username_url(username);
+    let url = user::get_username_url(username);
 
     let (status, json, _headers) =
         send_request(client, &Method::DELETE, url, None, None::<()>).await;

--- a/tcp-client/src/main.rs
+++ b/tcp-client/src/main.rs
@@ -1,11 +1,9 @@
-mod api;
-mod path;
-mod requests;
+pub mod api;
+pub mod path;
+pub mod requests;
 
 use api::{auth, sensor, session, session_sensor, session_sensor_data, user};
-use path::Path;
-use reqwest::Client;
-use tokio;
+use reqwest_wasm::Client;
 
 pub fn get_client() -> Client {
     let client = Client::new();
@@ -13,12 +11,6 @@ pub fn get_client() -> Client {
     return client;
 }
 
-pub fn get_path() -> Path {
-    let path = Path::new();
-
-    return path;
-}
-
-async fn main() {
+fn main() {
     println!("Starting client...");
 }

--- a/tcp-client/src/path.rs
+++ b/tcp-client/src/path.rs
@@ -1,87 +1,111 @@
-#![allow(dead_code)]
-
-use dotenv::dotenv;
 use std::env;
 
-#[derive(Debug)]
-pub struct Path {
-    pub base_url: String,
+fn get_base_url() -> String {
+    dotenv::dotenv().ok();
+    env::var("API_BASE_URL").unwrap_or_else(|_| "http://127.0.0.1:7878".to_string())
 }
 
-impl Path {
-    pub fn new() -> Self {
-        dotenv().ok();
-        let base_url =
-            env::var("API_BASE_URL").unwrap_or_else(|_| "http://127.0.0.1:7878".to_string());
+pub mod user {
+    use super::get_base_url;
 
-        Path { base_url }
+    pub fn get_user_url() -> String {
+        let base_url = get_base_url();
+        format!("{}/users", base_url)
     }
 
-    pub fn get_user_url(&self) -> String {
-        format!("{}/users", self.base_url)
+    pub fn get_profile_url() -> String {
+        let base_url = get_base_url();
+        format!("{}/users/profile", base_url)
     }
 
-    pub fn get_profile_url(&self) -> String {
-        format!("{}/users/profile", self.base_url)
+    pub fn get_username_url(username: &str) -> String {
+        let base_url = get_base_url();
+        format!("{}/users/{}", base_url, username)
+    }
+}
+
+pub mod auth {
+    use super::get_base_url;
+
+    pub fn get_login_url() -> String {
+        let base_url = get_base_url();
+        format!("{}/authentication/login", base_url)
     }
 
-    pub fn get_username_url(&self, username: &str) -> String {
-        format!("{}/users/{}", self.base_url, username)
+    pub fn get_logout_url() -> String {
+        let base_url = get_base_url();
+        format!("{}/authentication/logout", base_url)
     }
 
-    pub fn get_login_url(&self) -> String {
-        format!("{}/authentication/login", self.base_url)
+    pub fn get_renew_url() -> String {
+        let base_url = get_base_url();
+        format!("{}/authentication/renew", base_url)
+    }
+}
+
+pub mod sensor {
+    use super::get_base_url;
+
+    pub fn get_sensor_url() -> String {
+        let base_url = get_base_url();
+        format!("{}/sensors", base_url)
     }
 
-    pub fn get_logout_url(&self) -> String {
-        format!("{}/authentication/logout", self.base_url)
+    pub fn get_sensor_id_url(sensor_id: &str) -> String {
+        let base_url = get_base_url();
+        format!("{}/sensors/{}", base_url, sensor_id)
+    }
+}
+
+pub mod session {
+    use super::get_base_url;
+
+    pub fn get_sessions_url() -> String {
+        let base_url = get_base_url();
+        format!("{}/sessions", base_url)
     }
 
-    pub fn get_renew_url(&self) -> String {
-        format!("{}/authentication/renew", self.base_url)
+    pub fn get_sessions_exp_url(endpoint: &str) -> String {
+        let base_url = get_base_url();
+        format!("{}/sessions/{}", base_url, endpoint)
     }
 
-    pub fn get_sensor_url(&self) -> String {
-        format!("{}/sensors", self.base_url)
+    pub fn get_sessions_subpath_url(subpath: &str, endpoint: &str) -> String {
+        let base_url = get_base_url();
+        format!("{}/sessions/{}/{}", base_url, subpath, endpoint)
     }
 
-    pub fn get_sensor_id_url(&self, sensor_id: &str) -> String {
-        format!("{}/sensors/{}", self.base_url, sensor_id)
+    pub fn get_session_sensors_url() -> String {
+        let base_url = get_base_url();
+        format!("{}/sessions-sensors", base_url)
     }
 
-    pub fn get_sessions_url(&self) -> String {
-        format!("{}/sessions", self.base_url)
+    pub fn get_session_sensors_id_url(id: &str) -> String {
+        let base_url = get_base_url();
+        format!("{}/sessions-sensors/{}", base_url, id)
     }
 
-    pub fn get_sessions_exp_url(&self, endpoint: &str) -> String {
-        format!("{}/sessions/{}", self.base_url, endpoint)
+    pub fn get_session_sensors_subpath_url(subpath: &str, id: &str) -> String {
+        let base_url = get_base_url();
+        format!("{}/sessions-sensors/{}/{}", base_url, subpath, id)
+    }
+}
+
+pub mod datapoint {
+    use super::get_base_url;
+
+    pub fn get_datapoint_url() -> String {
+        let base_url = get_base_url();
+        format!("{}/sessions-sensors-data", base_url)
     }
 
-    pub fn get_sessions_subpath_url(&self, subpath: &str, endpoint: &str) -> String {
-        format!("{}/sessions/{}/{}", self.base_url, subpath, endpoint)
+    pub fn get_batch_url() -> String {
+        let base_url = get_base_url();
+        format!("{}/sessions-sensors-data/batch", base_url)
     }
 
-    pub fn get_session_sensors_url(&self) -> String {
-        format!("{}/sessions-sensors", self.base_url)
-    }
-
-    pub fn get_session_sensors_id_url(&self, id: &str) -> String {
-        format!("{}/sessions-sensors/{}", self.base_url, id)
-    }
-
-    pub fn get_session_sensors_subpath_url(&self, subpath: &str, id: &str) -> String {
-        format!("{}/sessions-sensors/{}/{}", self.base_url, subpath, id)
-    }
-
-    pub fn get_datapoint_url(&self) -> String {
-        format!("{}/sessions-sensors-data", self.base_url)
-    }
-
-    pub fn get_batch_url(&self) -> String {
-        format!("{}/sessions-sensors-data/batch", self.base_url)
-    }
-
-    pub fn get_datapoint_subpath_url(&self, subpath: &str, id: &str) -> String {
-        format!("{}/sessions-sensors-data/{}/{}", self.base_url, subpath, id)
+    pub fn get_datapoint_subpath_url(subpath: &str, id: &str) -> String {
+        let base_url = get_base_url();
+        format!("{}/sessions-sensors-data/{}/{}", base_url, subpath, id)
     }
 }

--- a/tcp-client/src/requests/send_request.rs
+++ b/tcp-client/src/requests/send_request.rs
@@ -1,5 +1,5 @@
-use reqwest::{
-    header::{HeaderMap, HeaderValue, CONTENT_TYPE, COOKIE},
+use reqwest_wasm::{
+    header::{HeaderMap, HeaderValue, CONTENT_LENGTH, CONTENT_TYPE, COOKIE},
     Client, Method,
 };
 use serde::Serialize;
@@ -8,21 +8,21 @@ use serde_json;
 pub async fn send_request<T>(
     client: &Client,
     method: &Method,
-    url: &str,
+    url: String,
     session_id: Option<&str>,
     body: Option<T>,
-) -> (reqwest::StatusCode, Option<serde_json::Value>, HeaderMap)
+) -> (reqwest_wasm::StatusCode, Option<serde_json::Value>, HeaderMap)
 where
     T: Serialize,
 {
     let mut request = client.request(method.clone(), url);
 
-    // Add CONTENT_TYPE header for POST and PATCH methods
+    // Add content-type header for POST and PATCH methods
     if *method == Method::POST || *method == Method::PATCH {
         request = request.header(CONTENT_TYPE, HeaderValue::from_static("application/json"));
     }
 
-    // Add session_id header if provided
+    // Add session_id in cookie header if provided
     if let Some(session_id) = session_id {
         match HeaderValue::from_str(&format!("session_id={}", session_id)) {
             Ok(value) => {
@@ -34,17 +34,27 @@ where
         }
     }
 
-    // Add request body if provided
+    // Check if there is a body to send in the request
     if let Some(body) = body {
+        // Serialize the body and get the length
+        let serialized_body = serde_json::to_vec(&body).unwrap();
+        let content_length = serialized_body.len();
+        
+        // Add content-length header
+        request = request.header(CONTENT_LENGTH, HeaderValue::from_str(&content_length.to_string()).unwrap());
+
+        // Add the json body to the request
         request = request.json(&body);
+    } else {
+        request = request.header(CONTENT_LENGTH, 0);
     }
 
-    // Send request and handle all errors
+    // Send request
     let res = match request.send().await {
         Ok(response) => response,
         Err(_) => {
             return (
-                reqwest::StatusCode::INTERNAL_SERVER_ERROR,
+                reqwest_wasm::StatusCode::INTERNAL_SERVER_ERROR,
                 None,
                 HeaderMap::new(),
             );
@@ -56,7 +66,7 @@ where
     let headers = res.headers().clone();
 
     // Receive json body if not No Content
-    let json = if status != reqwest::StatusCode::NO_CONTENT {
+    let json = if status != reqwest_wasm::StatusCode::NO_CONTENT {
         match res.json::<serde_json::Value>().await {
             Ok(body) => Some(body),
             Err(_) => None,


### PR DESCRIPTION
The following changes were made to either offload responsibilities from the caller or make code compatible with the UI layer:

- Removed the path crate and changed to public functions so that a path would not need to be passed around
- Changed from `reqwest` crate to `wasm-reqwest` for wasm compatibility
- Removed `tokio` crate for wasm compatibility
- Added library in Cargo.toml to allow API to be used as a library in the UI layer